### PR TITLE
Add host even if snmphost name not available

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -759,7 +759,7 @@ function createHost(
         $device['os'] = getHostOS($device);
 
         $snmphost = snmp_get($device, "sysName.0", "-Oqv", "SNMPv2-MIB");
-        if (host_exists($host, $snmphost)) {
+        if ($snmphost != 'none' && host_exists($host, $snmphost)) {
             throw new HostExistsException("Already have host $host ($snmphost) due to duplicate sysName");
         }
     }


### PR DESCRIPTION
Dahau cameras either don't have this property or it returns 'none'. In either case, I can't change it. I'd prefer not to force add the host as I want the snmp check to complete.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
